### PR TITLE
chore: provide authors in AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,13 @@
+<!--
+  - SPDX-FileCopyrightText: 2015 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: GPL-3.0-or-later
+-->
+# Authors
+
+- Andy Scherzinger <info@andy-scherzinger.de>
+- Christoph Wurst <christoph@winzerhof-wurst.at>
+- Ferdinand Thiessen <opensource@fthiessen.de>
+- Grigorii K. Shartsev <me@shgk.me>
+- Joas Schilling <coding@schilljs.com>
+- John Molakvoæ <skjnldsv@protonmail.com>
+- Pytal <24800714+Pytal@users.noreply.github.com>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/nextcloud-libraries/nextcloud-browser-storage"
   },
   "license": "GPL-3.0-or-later",
-  "author": "Christoph Wurst",
+  "author": "Nextcloud GmbH and Nextcloud contributors",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Similar as done for other libraries the package itself is maintained by Nextcloud and individual authors are tracked in the AUTHORS.md file.